### PR TITLE
[UPD] ssi_lead: perbaiki reminder_count agar notifikasi berhenti di batas

### DIFF
--- a/ssi_lead/data/ir_cron_data.xml
+++ b/ssi_lead/data/ir_cron_data.xml
@@ -3,12 +3,10 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 <record id="cron_compute_days_hours_on_stage" model="ir.cron">
-    <field name="name">CRM Lead: Compute Days/Hours on Stage</field>
+    <field name="name">CRM Lead: Compute Days/Hours on Stage and Send Reminders</field>
     <field name="model_id" ref="model_crm_lead" />
     <field name="state">code</field>
-    <field
-            name="code"
-        >model.search([('active', '=', True), ('stage_id.is_won', '=', False)])._compute_days_hours_on_stage()</field>
+    <field name="code">model._cron_check_send_reminders()</field>
     <field name="active" eval="False" />
     <field name="interval_number">1</field>
     <field name="interval_type">hours</field>

--- a/ssi_lead/models/crm_lead.py
+++ b/ssi_lead/models/crm_lead.py
@@ -126,7 +126,17 @@ class CrmLead(models.Model):
             else:
                 record.days_on_stage = 0.0
                 record.hours_on_stage = 0.0
-        self._check_and_send_reminders()
+
+    @api.model
+    def _cron_check_send_reminders(self):
+        records = self.search(
+            [
+                ("active", "=", True),
+                ("stage_id.is_won", "=", False),
+            ]
+        )
+        records._compute_days_hours_on_stage()
+        records._check_and_send_reminders()
 
     def _check_and_send_reminders(self):
         for record in self:
@@ -141,6 +151,11 @@ class CrmLead(models.Model):
                 )
                 if lead_total_hours >= threshold_total_hours:
                     reminder._send_notification(record)
+                    # Flush so reminder_count is refreshed before the next
+                    # cron run reads the guard above. Without this the count
+                    # stays stale and notifications keep being re-sent past
+                    # number_of_reminder.
+                    reminder.flush(["message_ids", "reminder_count"])
 
     @api.depends(
         "contractor_id",

--- a/ssi_lead/tests/test_data_ssi_lead.yaml
+++ b/ssi_lead/tests/test_data_ssi_lead.yaml
@@ -194,3 +194,98 @@ scenarios:
           number_of_reminder:
             type: "value"
             expected: 2
+
+  - name: "CRM Lead - Reminder count caps notifications at number_of_reminder"
+    steps:
+      - step: "Create CRM stage for reminder cap test"
+        action: "create"
+        model: "crm.stage"
+        save_as: "cap_stage"
+        values:
+          name: "Reminder Cap Stage SSI Lead"
+          sequence: 20
+
+      - step: "Get admin user for cap test"
+        action: "ref"
+        xml_id: "base.user_admin"
+        save_as: "cap_admin_user"
+
+      - step: "Get ir.model for crm.lead (cap test)"
+        action: "search"
+        model: "ir.model"
+        domain:
+          - ["model", "=", "crm.lead"]
+        save_as: "cap_crm_lead_model"
+        limit: 1
+
+      - step: "Create email template for cap test"
+        action: "create"
+        model: "mail.template"
+        save_as: "cap_email_tpl"
+        values:
+          name: "Reminder Cap Template SSI Lead"
+          model_id: "EVAL: registry['cap_crm_lead_model'].id"
+          subject: "Reminder: Lead has been in stage too long"
+          body_html: "<p>Please review your lead.</p>"
+
+      - step: "Create lead for cap test"
+        action: "create"
+        model: "crm.lead"
+        save_as: "cap_lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Lead Reminder Cap"
+          stage_id: "EVAL: registry['cap_stage'].id"
+
+      - step: "Create lead reminder with threshold 0 and limit 2"
+        action: "create"
+        model: "crm.lead.reminder"
+        save_as: "cap_reminder"
+        values:
+          lead_id: "EVAL: registry['cap_lead'].id"
+          stage_id: "EVAL: registry['cap_stage'].id"
+          days_on_stage: 0
+          hours_on_stage: 0
+          email_template_id: "EVAL: registry['cap_email_tpl'].id"
+          number_of_reminder: 2
+          user_ids:
+            - "EVAL: registry['cap_admin_user'].id"
+
+      - step: "First reminder check sends notification"
+        action: "call"
+        target: "cap_lead"
+        method: "_check_and_send_reminders"
+
+      - step: "Assert reminder_count is 1 after first check"
+        action: "assert"
+        target: "cap_reminder"
+        asserts:
+          reminder_count:
+            type: "value"
+            expected: 1
+
+      - step: "Second reminder check sends notification"
+        action: "call"
+        target: "cap_lead"
+        method: "_check_and_send_reminders"
+
+      - step: "Assert reminder_count is 2 after second check"
+        action: "assert"
+        target: "cap_reminder"
+        asserts:
+          reminder_count:
+            type: "value"
+            expected: 2
+
+      - step: "Third reminder check must NOT send (limit reached)"
+        action: "call"
+        target: "cap_lead"
+        method: "_check_and_send_reminders"
+
+      - step: "Assert reminder_count stays capped at 2"
+        action: "assert"
+        target: "cap_reminder"
+        asserts:
+          reminder_count:
+            type: "value"
+            expected: 2


### PR DESCRIPTION
## Masalah

Sistem reminder pada `crm.lead` terus mengirim notifikasi walaupun jumlah pengiriman sudah melewati `number_of_reminder`. `reminder_count` tidak terhitung dengan andal.

## Akar masalah

`_check_and_send_reminders()` (yang memanggil `_send_notification` → menulis `message_ids`) dijalankan **di dalam** metode compute `_compute_days_hours_on_stage`. Menulis field relasional dan mengandalkan recompute field tersimpan (`reminder_count`) dari dalam metode compute tidak andal di Odoo, sehingga guard `reminder_count >= number_of_reminder` membaca nilai basi dan notifikasi terus terkirim.

## Perubahan

* Memindahkan logika pengiriman reminder keluar dari metode compute ke metode khusus `_cron_check_send_reminders()` yang dipanggil langsung oleh cron.
* Cron `cron_compute_days_hours_on_stage` kini memanggil `model._cron_check_send_reminders()`.
* Menambahkan `flush()` pada `message_ids`/`reminder_count` setelah notifikasi dikirim agar guard membaca nilai terbaru.
* Menambahkan skenario unit test yang memverifikasi `reminder_count` berhenti tepat di `number_of_reminder` (kirim 2x lalu berhenti).

## Pengujian

`addons update --test --with ssi_lead` → `0 failed, 0 error(s)`. Skenario baru "Reminder count caps notifications at number_of_reminder" lolos.