### PR TITLE
[FIX] ssi_lead

### DIFF
--- a/ssi_lead/models/crm_lead.py
+++ b/ssi_lead/models/crm_lead.py
@@ -151,11 +151,6 @@ class CrmLead(models.Model):
                 )
                 if lead_total_hours >= threshold_total_hours:
                     reminder._send_notification(record)
-                    # Flush so reminder_count is refreshed before the next
-                    # cron run reads the guard above. Without this the count
-                    # stays stale and notifications keep being re-sent past
-                    # number_of_reminder.
-                    reminder.flush(["message_ids", "reminder_count"])
 
     @api.depends(
         "contractor_id",

--- a/ssi_lead/models/crm_lead_reminder.py
+++ b/ssi_lead/models/crm_lead_reminder.py
@@ -85,3 +85,5 @@ class CrmLeadReminder(models.Model):  # pylint: disable=too-few-public-methods
         )
         if message:
             self.message_ids = [(4, message.id)]
+            self._compute_reminder_count()
+            self.flush(["message_ids", "reminder_count"])

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -54,7 +54,8 @@ class TestSsiLead(YamlTransactionCase):
 
         # Simulate a fresh cron transaction: discard ORM cache so the next
         # read comes from DB, not from in-memory.
-        self.env.invalidate_all()
+        # Note: invalidate_all() is Odoo 16+; in Odoo 14 use invalidate_cache()
+        reminder.invalidate_cache(["reminder_count", "message_ids"])
 
         self.assertEqual(
             reminder.reminder_count,
@@ -66,7 +67,7 @@ class TestSsiLead(YamlTransactionCase):
         # DB.  If the fix is correct, reminder_count == 1 >= number_of_reminder
         # == 1, so no notification is sent.
         lead._check_and_send_reminders()
-        self.env.invalidate_all()
+        reminder.invalidate_cache(["reminder_count", "message_ids"])
 
         self.assertEqual(
             reminder.reminder_count,

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -11,3 +11,66 @@ from odoo.tests import tagged
 class TestSsiLead(YamlTransactionCase):
     def test_ssi_lead(self):
         self.run_yaml_scenario("test_data_ssi_lead.yaml")
+
+    def test_reminder_count_persists_to_db(self):
+        """reminder_count must be written to DB after _send_notification so that
+        a fresh ORM env (simulating the next cron run) still sees the cap.
+
+        The YAML scenario 'Reminder count caps notifications' passes even with
+        the bug because all three _check_and_send_reminders calls share the same
+        ORM cache — reminder_count stays correct in-memory even if it was never
+        flushed to DB.  This test reproduces the cross-transaction failure by
+        calling env.invalidate_all() between checks, forcing a DB read.
+        """
+        stage = self.env["crm.stage"].create(
+            {"name": "DB Persist Reminder Stage", "sequence": 99}
+        )
+        model_id = self.env["ir.model"].search([("model", "=", "crm.lead")], limit=1).id
+        tpl = self.env["mail.template"].create(
+            {
+                "name": "DB Persist Reminder Template",
+                "model_id": model_id,
+                "subject": "Reminder",
+                "body_html": "<p>Reminder body.</p>",
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {"name": "DB Persist Lead", "stage_id": stage.id}
+        )
+        reminder = self.env["crm.lead.reminder"].create(
+            {
+                "lead_id": lead.id,
+                "stage_id": stage.id,
+                "days_on_stage": 0,
+                "hours_on_stage": 0,
+                "email_template_id": tpl.id,
+                "number_of_reminder": 1,
+                "user_ids": [(6, 0, [self.env.ref("base.user_admin").id])],
+            }
+        )
+
+        # First check — threshold met immediately (0 hours), should send once.
+        lead._check_and_send_reminders()
+
+        # Simulate a fresh cron transaction: discard ORM cache so the next
+        # read comes from DB, not from in-memory.
+        self.env.invalidate_all()
+
+        self.assertEqual(
+            reminder.reminder_count,
+            1,
+            "reminder_count must be 1 in DB after the first send",
+        )
+
+        # Second check — cache was cleared, so guard reads reminder_count from
+        # DB.  If the fix is correct, reminder_count == 1 >= number_of_reminder
+        # == 1, so no notification is sent.
+        lead._check_and_send_reminders()
+        self.env.invalidate_all()
+
+        self.assertEqual(
+            reminder.reminder_count,
+            1,
+            "reminder_count must NOT increase beyond number_of_reminder after "
+            "the cache is cleared between checks",
+        )


### PR DESCRIPTION
* Perbaiki bug reminder dikirim melebihi number_of_reminder Root cause: flush() di Odoo 14 tidak men-trigger recompute stored computed field reminder_count secara deterministik — nilai di DB tetap 0 setelah notifikasi dikirim, sehingga guard reminder_count >= number_of_reminder selalu lolos di cron run berikutnya
* Tambah _compute_reminder_count() eksplisit + flush() di dalam _send_notification() agar nilai reminder_count langsung ditulis ke DB
* Hapus flush() duplikat dari _check_and_send_reminders()
* Tambah test_reminder_count_persists_to_db() yang mensimulasikan skenario lintas transaksi via env.invalidate_all() untuk menutup celah yang menyebabkan YAML test lolos meski kode masih buggy