### PR TITLE
[FIX] ssi_lead: commit reminder_count immediately after notification sent

### DIFF
--- a/ssi_lead/models/crm_lead_reminder.py
+++ b/ssi_lead/models/crm_lead_reminder.py
@@ -81,3 +81,4 @@ class CrmLeadReminder(models.Model):  # pylint: disable=too-few-public-methods
         if message:
             self.message_ids = [(4, message.id)]
             self.write({"reminder_count": self.reminder_count + 1})
+            self.env.cr.commit()  # pylint: disable=invalid-commit


### PR DESCRIPTION
## Summary

- Root cause: `WorkerCron` is killed after 120s timeout, causing a full transaction rollback. `reminder_count` writes are lost, so the next cron run re-sends all notifications from scratch — resulting in thousands of duplicate Telegram notifications.
- Fix: add `env.cr.commit()` immediately after each `write({"reminder_count": ...})` in `_send_notification()`. This persists the counter atomically per-lead, so even if the worker is killed mid-batch, already-processed leads are not re-notified.

## Test plan

- [ ] Existing YAML scenario "Reminder count caps notifications at number_of_reminder" still passes
- [ ] `test_reminder_count_persists_to_db` still passes — `cr.commit()` makes the DB-read assertion even more reliable
- [ ] On production: activate cron, verify `reminder_count > 0` after first run and no duplicate notifications on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)