### PR TITLE
[UPD] ssi_lead

### DIFF
--- a/ssi_lead/__manifest__.py
+++ b/ssi_lead/__manifest__.py
@@ -30,6 +30,7 @@
         "security/res_groups/crm_team_role.xml",
         "security/ir_model_access/crm_team_role.xml",
         "security/ir_model_access/crm_team_member_role.xml",
+        "security/ir_model_access/crm_team_stage_restriction.xml",
         "security/ir_rule/crm_lead.xml",
         "data/ir_sequence_data.xml",
         "data/sequence_template_data.xml",

--- a/ssi_lead/models/__init__.py
+++ b/ssi_lead/models/__init__.py
@@ -10,4 +10,5 @@ from . import (  # noqa: F401
     crm_team,
     crm_team_reminder,
     crm_team_member_role,
+    crm_team_stage_restriction,
 )

--- a/ssi_lead/models/crm_lead.py
+++ b/ssi_lead/models/crm_lead.py
@@ -2,7 +2,8 @@
 # Copyright 2023 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class CrmLead(models.Model):
@@ -168,6 +169,42 @@ class CrmLead(models.Model):
                 result = Partner.search(criteria).ids
             record.allowed_contact_contractor_ids = result
 
+    def _check_stage_transition_restriction(self, values):
+        new_stage_id = values.get("stage_id")
+        for record in self:
+            if not record.team_id:
+                continue
+            if new_stage_id == record.stage_id.id:
+                continue
+            from_stage = record.stage_id
+            to_stage = (
+                self.env["crm.stage"].browse(new_stage_id)
+                if new_stage_id
+                else self.env["crm.stage"]
+            )
+            restrictions = record.team_id.stage_restriction_ids.filtered(
+                lambda r: (not r.from_stage_id or r.from_stage_id == from_stage)
+                and (not r.to_stage_id or r.to_stage_id == to_stage)
+            )
+            if restrictions:
+                error_message = _(
+                    """
+Context: Change Opportunity Stage
+Database ID: %s
+Problem: Sales team "%s" does not allow moving from stage "%s" to stage "%s".
+Solution: Choose a different stage, or update the restriction rules on tab
+Stage Restrictions of sales team "%s".
+"""
+                    % (
+                        record.id,
+                        record.team_id.name,
+                        from_stage.name or "(none)",
+                        to_stage.name or "(none)",
+                        record.team_id.name,
+                    )
+                )
+                raise UserError(error_message)
+
     @api.model
     def create(self, values):
         _super = super(CrmLead, self)  # pylint: disable=super-with-arguments
@@ -200,6 +237,8 @@ class CrmLead(models.Model):
         return result
 
     def write(self, values):
+        if "stage_id" in values:
+            self._check_stage_transition_restriction(values)
         result = super(CrmLead, self).write(  # pylint: disable=super-with-arguments
             values
         )

--- a/ssi_lead/models/crm_team.py
+++ b/ssi_lead/models/crm_team.py
@@ -20,3 +20,9 @@ class CrmTeam(models.Model):  # pylint: disable=too-few-public-methods
         inverse_name="team_id",
         help="Roles within this sales team and the users filling each role.",
     )
+    stage_restriction_ids = fields.One2many(
+        string="Stage Restrictions",
+        comodel_name="crm.team.stage_restriction",
+        inverse_name="team_id",
+        help="Stage transitions that are forbidden for leads on this " "sales team.",
+    )

--- a/ssi_lead/models/crm_team_stage_restriction.py
+++ b/ssi_lead/models/crm_team_stage_restriction.py
@@ -41,6 +41,12 @@ class CrmTeamStageRestriction(models.Model):
         "this stage. Leave empty to match any destination stage.",
     )
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._check_from_or_to_stage_required()
+        return records
+
     @api.constrains("from_stage_id", "to_stage_id")
     def _check_from_or_to_stage_required(self):
         for record in self:

--- a/ssi_lead/models/crm_team_stage_restriction.py
+++ b/ssi_lead/models/crm_team_stage_restriction.py
@@ -1,0 +1,57 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class CrmTeamStageRestriction(models.Model):
+    """
+    Represents a stage-transition restriction rule scoped to one sales
+    team: leads belonging to that team may not move from
+    `from_stage_id` to `to_stage_id`. Either field may be left empty to
+    match "any stage" on that side of the transition, but at least one
+    of the two must be set.
+    """
+
+    _name = "crm.team.stage_restriction"
+    _description = "CRM Sales Team Stage Restriction"
+    _order = "team_id, from_stage_id, to_stage_id"
+
+    team_id = fields.Many2one(
+        string="Sales Team",
+        comodel_name="crm.team",
+        required=True,
+        ondelete="cascade",
+        help="Sales team this stage restriction applies to.",
+    )
+    from_stage_id = fields.Many2one(
+        string="From Stage",
+        comodel_name="crm.stage",
+        ondelete="restrict",
+        help="Restriction applies when the lead is currently in this "
+        "stage. Leave empty to match any origin stage.",
+    )
+    to_stage_id = fields.Many2one(
+        string="To Stage",
+        comodel_name="crm.stage",
+        ondelete="restrict",
+        help="Restriction applies when the lead is being moved into "
+        "this stage. Leave empty to match any destination stage.",
+    )
+
+    @api.constrains("from_stage_id", "to_stage_id")
+    def _check_from_or_to_stage_required(self):
+        for record in self:
+            if not record.from_stage_id and not record.to_stage_id:
+                error_message = _(
+                    """
+Context: Configure sales team stage restriction
+Database ID: %s
+Problem: Both "From Stage" and "To Stage" are empty.
+Solution: Fill in at least one of "From Stage" or "To Stage".
+"""
+                    % (record.id,)
+                )
+                raise ValidationError(error_message)

--- a/ssi_lead/security/ir_model_access/crm_team_stage_restriction.xml
+++ b/ssi_lead/security/ir_model_access/crm_team_stage_restriction.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="crm_team_stage_restriction_access_user" model="ir.model.access">
+    <field name="name">crm_team_stage_restriction - user</field>
+    <field name="model_id" ref="model_crm_team_stage_restriction" />
+    <field name="group_id" ref="base.group_user" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+</odoo>

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -4,7 +4,7 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
 
@@ -111,3 +111,191 @@ class TestSsiLead(YamlTransactionCase):
             "reminder_count must NOT increase beyond number_of_reminder after "
             "the cache is cleared between checks",
         )
+
+    def test_stage_restriction_blocks_specific_pair(self):
+        """A restriction with both from_stage_id and to_stage_id set must
+        block that exact stage pair transition.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - B", "sequence": 2}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Test Team - Pair",
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "from_stage_id": stage_a.id,
+                            "to_stage_id": stage_b.id,
+                        },
+                    )
+                ],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - Pair",
+                "team_id": team.id,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        with self.assertRaises(UserError):
+            lead.write({"stage_id": stage_b.id})
+
+    def test_stage_restriction_blocks_from_stage_only(self):
+        """A restriction with only from_stage_id set must block moving away
+        from that stage to any destination.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - From Only A", "sequence": 1}
+        )
+        stage_c = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - From Only C", "sequence": 2}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Test Team - From Only",
+                "stage_restriction_ids": [(0, 0, {"from_stage_id": stage_a.id})],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - From Only",
+                "team_id": team.id,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        with self.assertRaises(UserError):
+            lead.write({"stage_id": stage_c.id})
+
+    def test_stage_restriction_blocks_to_stage_only(self):
+        """A restriction with only to_stage_id set must block moving into
+        that stage from any origin.
+        """
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - To Only B", "sequence": 1}
+        )
+        stage_c = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - To Only C", "sequence": 2}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Test Team - To Only",
+                "stage_restriction_ids": [(0, 0, {"to_stage_id": stage_b.id})],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - To Only",
+                "team_id": team.id,
+                "stage_id": stage_c.id,
+            }
+        )
+
+        with self.assertRaises(UserError):
+            lead.write({"stage_id": stage_b.id})
+
+    def test_stage_restriction_ignored_without_team(self):
+        """A lead without a sales team must never be blocked, even if an
+        identical restriction is configured on some sales team.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - No Team A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - No Team B", "sequence": 2}
+        )
+        self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Test Team - No Team",
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "from_stage_id": stage_a.id,
+                            "to_stage_id": stage_b.id,
+                        },
+                    )
+                ],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - No Team",
+                "team_id": False,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        lead.write({"stage_id": stage_b.id})
+
+        self.assertEqual(lead.stage_id, stage_b)
+
+    def test_stage_restriction_not_enforced_on_create(self):
+        """A restriction must never block the initial stage set at
+        creation time, even if that stage would be forbidden as a
+        destination on write().
+        """
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - Create B", "sequence": 1}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Test Team - Create",
+                "stage_restriction_ids": [(0, 0, {"to_stage_id": stage_b.id})],
+            }
+        )
+
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - Create",
+                "team_id": team.id,
+                "stage_id": stage_b.id,
+            }
+        )
+
+        self.assertEqual(lead.stage_id, stage_b)
+
+    def test_stage_restriction_allows_unlisted_transition(self):
+        """A stage transition that matches no configured restriction rule
+        must succeed as usual.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - Unlisted A", "sequence": 1}
+        )
+        stage_d = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - Unlisted D", "sequence": 2}
+        )
+        team = self.env["crm.team"].create(
+            {"name": "Stage Restriction Test Team - Unlisted"}
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Lead - Unlisted",
+                "team_id": team.id,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        lead.write({"stage_id": stage_d.id})
+
+        self.assertEqual(lead.stage_id, stage_d)
+
+    def test_stage_restriction_requires_from_or_to_stage(self):
+        """crm.team.stage_restriction must reject a line where both
+        from_stage_id and to_stage_id are empty.
+        """
+        team = self.env["crm.team"].create(
+            {"name": "Stage Restriction Test Team - Constraint"}
+        )
+
+        with self.assertRaises(ValidationError):
+            self.env["crm.team.stage_restriction"].create({"team_id": team.id})

--- a/ssi_lead/views/crm_team_views.xml
+++ b/ssi_lead/views/crm_team_views.xml
@@ -35,6 +35,20 @@
                     </tree>
                 </field>
             </page>
+            <page name="stage_restrictions" string="Stage Restrictions">
+                <field name="stage_restriction_ids">
+                    <tree editable="bottom">
+                        <field
+                                name="from_stage_id"
+                                domain="[('team_id', 'in', (False, parent.id))]"
+                            />
+                        <field
+                                name="to_stage_id"
+                                domain="[('team_id', 'in', (False, parent.id))]"
+                            />
+                    </tree>
+                </field>
+            </page>
         </xpath>
     </field>
 </record>


### PR DESCRIPTION
* Menambahkan model crm.team.stage_restriction untuk membatasi transisi stage per sales team (from_stage_id/to_stage_id opsional, minimal salah satu wajib diisi)
* Menambahkan tab "Stage Restrictions" pada form Sales Team
* Menolak perpindahan stage_id pada crm.lead yang cocok dengan restriksi tim; restriksi diabaikan bila lead tanpa team_id dan tidak berlaku saat create()
* Menambahkan unit test untuk seluruh skenario (blokir pasangan stage, blokir from/to stage saja, tanpa team, saat create, transisi bebas, dan constraint model detail)

Ref: BL-0065