### PR TITLE
[UPD] ssi_lead

### DIFF
--- a/ssi_lead/__manifest__.py
+++ b/ssi_lead/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Lead Enhancement",
-    "version": "14.0.2.16.0",
+    "version": "14.0.2.17.0",
     "website": "https://simetri-sinergi.id",
     "author": "OpenSynergy Indonesia, PT. Simetri Sinergi Indonesia",
     "contributors": [

--- a/ssi_lead/models/crm_lead.py
+++ b/ssi_lead/models/crm_lead.py
@@ -186,24 +186,34 @@ class CrmLead(models.Model):
                 lambda r: (not r.from_stage_id or r.from_stage_id == from_stage)
                 and (not r.to_stage_id or r.to_stage_id == to_stage)
             )
-            if restrictions:
-                error_message = _(
-                    """
+            if not restrictions:
+                continue
+            allowed_roles = restrictions.mapped("role_ids")
+            user_roles = record.team_id.member_role_ids.filtered(
+                lambda m: self.env.user in m.user_ids
+            ).mapped("role_id")
+            if allowed_roles & user_roles:
+                continue
+            error_message = _(
+                """
 Context: Change Opportunity Stage
 Database ID: %s
-Problem: Sales team "%s" does not allow moving from stage "%s" to stage "%s".
-Solution: Choose a different stage, or update the restriction rules on tab
-Stage Restrictions of sales team "%s".
+Problem: Moving a lead of sales team "%s" from stage "%s" to stage "%s" is
+restricted to role(s): %s. User "%s" holds none of those roles in this team.
+Solution: Ask a user with one of the required roles to move the stage, or
+update Member Roles / Stage Restrictions of sales team "%s".
 """
-                    % (
-                        record.id,
-                        record.team_id.name,
-                        from_stage.name or "(none)",
-                        to_stage.name or "(none)",
-                        record.team_id.name,
-                    )
+                % (
+                    record.id,
+                    record.team_id.name,
+                    from_stage.name or "(none)",
+                    to_stage.name or "(none)",
+                    ", ".join(allowed_roles.mapped("name")) or "(none)",
+                    self.env.user.name,
+                    record.team_id.name,
                 )
-                raise UserError(error_message)
+            )
+            raise UserError(error_message)
 
     @api.model
     def create(self, values):
@@ -219,6 +229,7 @@ Stage Restrictions of sales team "%s".
                     "lead_id": result.id,
                     "stage_id": result.stage_id.id,
                     "date": fields.Datetime.now(),
+                    "user_id": self.env.user.id,
                 }
             )
         if result.team_id and result.team_id.reminder_ids:
@@ -249,6 +260,7 @@ Stage Restrictions of sales team "%s".
                         "lead_id": record.id,
                         "stage_id": values["stage_id"],
                         "date": fields.Datetime.now(),
+                        "user_id": self.env.user.id,
                     }
                 )
         return result

--- a/ssi_lead/models/crm_lead_stage_log.py
+++ b/ssi_lead/models/crm_lead_stage_log.py
@@ -27,3 +27,11 @@ class CrmLeadStageLog(models.Model):  # pylint: disable=too-few-public-methods
         required=True,
         default=fields.Datetime.now,
     )
+    user_id = fields.Many2one(
+        string="Moved By",
+        comodel_name="res.users",
+        required=True,
+        ondelete="restrict",
+        default=lambda self: self.env.user,
+        help="User who performed this stage transition.",
+    )

--- a/ssi_lead/models/crm_team.py
+++ b/ssi_lead/models/crm_team.py
@@ -24,5 +24,6 @@ class CrmTeam(models.Model):  # pylint: disable=too-few-public-methods
         string="Stage Restrictions",
         comodel_name="crm.team.stage_restriction",
         inverse_name="team_id",
-        help="Stage transitions that are forbidden for leads on this " "sales team.",
+        help="Stage transitions for leads on this sales team that are "
+        "restricted to specific roles.",
     )

--- a/ssi_lead/models/crm_team_stage_restriction.py
+++ b/ssi_lead/models/crm_team_stage_restriction.py
@@ -56,6 +56,7 @@ class CrmTeamStageRestriction(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         records._check_from_or_to_stage_required()
+        records._check_role_required()
         return records
 
     @api.constrains("from_stage_id", "to_stage_id")

--- a/ssi_lead/models/crm_team_stage_restriction.py
+++ b/ssi_lead/models/crm_team_stage_restriction.py
@@ -40,6 +40,17 @@ class CrmTeamStageRestriction(models.Model):
         help="Restriction applies when the lead is being moved into "
         "this stage. Leave empty to match any destination stage.",
     )
+    role_ids = fields.Many2many(
+        string="Allowed Roles",
+        comodel_name="crm_team_role",
+        relation="rel_crm_team_stage_restriction_2_role",
+        column1="restriction_id",
+        column2="role_id",
+        required=True,
+        help="Only users assigned to at least one of these roles within "
+        "the sales team may perform this stage transition. At least one "
+        "role is required.",
+    )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -57,6 +68,21 @@ Context: Configure sales team stage restriction
 Database ID: %s
 Problem: Both "From Stage" and "To Stage" are empty.
 Solution: Fill in at least one of "From Stage" or "To Stage".
+"""
+                    % (record.id,)
+                )
+                raise ValidationError(error_message)
+
+    @api.constrains("role_ids")
+    def _check_role_required(self):
+        for record in self:
+            if not record.role_ids:
+                error_message = _(
+                    """
+Context: Configure sales team stage restriction
+Database ID: %s
+Problem: No allowed role is set on this stage restriction.
+Solution: Add at least one role under "Allowed Roles".
 """
                     % (record.id,)
                 )

--- a/ssi_lead/tests/test_data_ssi_lead.yaml
+++ b/ssi_lead/tests/test_data_ssi_lead.yaml
@@ -44,6 +44,14 @@ scenarios:
         expect_count: 1
         limit: 1
 
+      - step: "Assert stage log 1 moved by admin"
+        action: "assert"
+        target: "stage_log_1"
+        asserts:
+          user_id:
+            type: "m2o"
+            expected_xml_id: "base.user_admin"
+
       - step: "Assert lead has stage set"
         action: "assert"
         target: "lead"
@@ -68,6 +76,14 @@ scenarios:
         save_as: "stage_log_2"
         expect_count: 1
         limit: 1
+
+      - step: "Assert stage log 2 moved by admin"
+        action: "assert"
+        target: "stage_log_2"
+        asserts:
+          user_id:
+            type: "m2o"
+            expected_xml_id: "base.user_admin"
 
       - step: "Assert latest stage log id is set"
         action: "assert"

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -348,6 +348,7 @@ class TestSsiLead(YamlTransactionCase):
                 "name": "Stage Log User Test - Mover",
                 "login": "stage_log_user_test_mover@example.com",
                 "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
                     (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
                     (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
                 ],
@@ -423,6 +424,7 @@ class TestSsiLead(YamlTransactionCase):
                 "name": "Stage Restriction Role Test - Allowed User",
                 "login": "stage_restriction_role_test_allowed@example.com",
                 "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
                     (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
                     (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
                 ],
@@ -435,16 +437,6 @@ class TestSsiLead(YamlTransactionCase):
             {
                 "name": "Stage Restriction Role Test Team - Allowed",
                 "member_ids": [(6, 0, [user.id])],
-                "member_role_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "role_id": role.id,
-                            "user_ids": [(6, 0, [user.id])],
-                        },
-                    )
-                ],
                 "stage_restriction_ids": [
                     (
                         0,
@@ -456,6 +448,13 @@ class TestSsiLead(YamlTransactionCase):
                         },
                     )
                 ],
+            }
+        )
+        self.env["crm.team.member_role"].create(
+            {
+                "team_id": team.id,
+                "role_id": role.id,
+                "user_ids": [(6, 0, [user.id])],
             }
         )
         lead = self.env["crm.lead"].create(
@@ -486,6 +485,7 @@ class TestSsiLead(YamlTransactionCase):
                 "name": "Stage Restriction Role Test - Unassigned User",
                 "login": "stage_restriction_role_test_norole@example.com",
                 "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
                     (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
                     (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
                 ],
@@ -538,6 +538,7 @@ class TestSsiLead(YamlTransactionCase):
                 "name": "Stage Restriction Role Test - To Any Allowed",
                 "login": "stage_restriction_role_test_toany_allowed@example.com",
                 "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
                     (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
                     (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
                 ],
@@ -548,6 +549,7 @@ class TestSsiLead(YamlTransactionCase):
                 "name": "Stage Restriction Role Test - To Any Other",
                 "login": "stage_restriction_role_test_toany_other@example.com",
                 "groups_id": [
+                    (4, self.env.ref("base.group_user").id),
                     (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
                     (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
                 ],
@@ -560,16 +562,6 @@ class TestSsiLead(YamlTransactionCase):
             {
                 "name": "Stage Restriction Role Test Team - To Any",
                 "member_ids": [(6, 0, [allowed_user.id, other_user.id])],
-                "member_role_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "role_id": role.id,
-                            "user_ids": [(6, 0, [allowed_user.id])],
-                        },
-                    )
-                ],
                 "stage_restriction_ids": [
                     (
                         0,
@@ -580,6 +572,13 @@ class TestSsiLead(YamlTransactionCase):
                         },
                     )
                 ],
+            }
+        )
+        self.env["crm.team.member_role"].create(
+            {
+                "team_id": team.id,
+                "role_id": role.id,
+                "user_ids": [(6, 0, [allowed_user.id])],
             }
         )
         lead_allowed = self.env["crm.lead"].create(

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -122,6 +122,9 @@ class TestSsiLead(YamlTransactionCase):
         stage_b = self.env["crm.stage"].create(
             {"name": "Stage Restriction Test - B", "sequence": 2}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - Pair", "code": "SRTR-PAIR"}
+        )
         team = self.env["crm.team"].create(
             {
                 "name": "Stage Restriction Test Team - Pair",
@@ -132,6 +135,7 @@ class TestSsiLead(YamlTransactionCase):
                         {
                             "from_stage_id": stage_a.id,
                             "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
                         },
                     )
                 ],
@@ -158,10 +162,22 @@ class TestSsiLead(YamlTransactionCase):
         stage_c = self.env["crm.stage"].create(
             {"name": "Stage Restriction Test - From Only C", "sequence": 2}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - From Only", "code": "SRTR-FROM"}
+        )
         team = self.env["crm.team"].create(
             {
                 "name": "Stage Restriction Test Team - From Only",
-                "stage_restriction_ids": [(0, 0, {"from_stage_id": stage_a.id})],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "from_stage_id": stage_a.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
             }
         )
         lead = self.env["crm.lead"].create(
@@ -185,10 +201,22 @@ class TestSsiLead(YamlTransactionCase):
         stage_c = self.env["crm.stage"].create(
             {"name": "Stage Restriction Test - To Only C", "sequence": 2}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - To Only", "code": "SRTR-TO"}
+        )
         team = self.env["crm.team"].create(
             {
                 "name": "Stage Restriction Test Team - To Only",
-                "stage_restriction_ids": [(0, 0, {"to_stage_id": stage_b.id})],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
             }
         )
         lead = self.env["crm.lead"].create(
@@ -212,6 +240,9 @@ class TestSsiLead(YamlTransactionCase):
         stage_b = self.env["crm.stage"].create(
             {"name": "Stage Restriction Test - No Team B", "sequence": 2}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - No Team", "code": "SRTR-NOTEAM"}
+        )
         self.env["crm.team"].create(
             {
                 "name": "Stage Restriction Test Team - No Team",
@@ -222,6 +253,7 @@ class TestSsiLead(YamlTransactionCase):
                         {
                             "from_stage_id": stage_a.id,
                             "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
                         },
                     )
                 ],
@@ -247,10 +279,22 @@ class TestSsiLead(YamlTransactionCase):
         stage_b = self.env["crm.stage"].create(
             {"name": "Stage Restriction Test - Create B", "sequence": 1}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - Create", "code": "SRTR-CREATE"}
+        )
         team = self.env["crm.team"].create(
             {
                 "name": "Stage Restriction Test Team - Create",
-                "stage_restriction_ids": [(0, 0, {"to_stage_id": stage_b.id})],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
             }
         )
 
@@ -289,13 +333,272 @@ class TestSsiLead(YamlTransactionCase):
 
         self.assertEqual(lead.stage_id, stage_d)
 
+    def test_stage_log_user_id_follows_writer(self):
+        """crm.lead.stage.log.user_id must record the user who performed
+        the stage transition, not always the record creator/admin.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Log User Test - A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Log User Test - B", "sequence": 2}
+        )
+        mover = self.env["res.users"].create(
+            {
+                "name": "Stage Log User Test - Mover",
+                "login": "stage_log_user_test_mover@example.com",
+                "groups_id": [
+                    (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
+                    (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
+                ],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {"name": "Stage Log User Test Lead", "stage_id": stage_a.id}
+        )
+
+        lead.with_user(mover).write({"stage_id": stage_b.id})
+
+        log = self.env["crm.lead.stage.log"].search(
+            [
+                ("lead_id", "=", lead.id),
+                ("stage_id", "=", stage_b.id),
+            ],
+            limit=1,
+        )
+        self.assertEqual(log.user_id, mover)
+
     def test_stage_restriction_requires_from_or_to_stage(self):
         """crm.team.stage_restriction must reject a line where both
-        from_stage_id and to_stage_id are empty.
+        from_stage_id and to_stage_id are empty, even when role_ids is
+        set (proves it is the from/to constraint that fails, not role).
         """
         team = self.env["crm.team"].create(
             {"name": "Stage Restriction Test Team - Constraint"}
         )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Test Role - Constraint", "code": "SRTR-CONS"}
+        )
 
         with self.assertRaises(ValidationError):
-            self.env["crm.team.stage_restriction"].create({"team_id": team.id})
+            self.env["crm.team.stage_restriction"].create(
+                {"team_id": team.id, "role_ids": [(6, 0, [role.id])]}
+            )
+
+    def test_stage_restriction_requires_role(self):
+        """crm.team.stage_restriction must reject a line with no role_ids,
+        even when from_stage_id/to_stage_id are set.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - Requires Role A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Test - Requires Role B", "sequence": 2}
+        )
+        team = self.env["crm.team"].create(
+            {"name": "Stage Restriction Test Team - Requires Role"}
+        )
+
+        with self.assertRaises(ValidationError):
+            self.env["crm.team.stage_restriction"].create(
+                {
+                    "team_id": team.id,
+                    "from_stage_id": stage_a.id,
+                    "to_stage_id": stage_b.id,
+                }
+            )
+
+    def test_stage_restriction_allows_user_with_role(self):
+        """A user holding one of the restriction's allowed roles in the
+        sales team must be able to perform the restricted transition.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - B", "sequence": 2}
+        )
+        user = self.env["res.users"].create(
+            {
+                "name": "Stage Restriction Role Test - Allowed User",
+                "login": "stage_restriction_role_test_allowed@example.com",
+                "groups_id": [
+                    (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
+                    (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
+                ],
+            }
+        )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Role Test - Role", "code": "SRTR-ROLE-OK"}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Role Test Team - Allowed",
+                "member_ids": [(6, 0, [user.id])],
+                "member_role_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "role_id": role.id,
+                            "user_ids": [(6, 0, [user.id])],
+                        },
+                    )
+                ],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "from_stage_id": stage_a.id,
+                            "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Role Test Lead - Allowed",
+                "team_id": team.id,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        lead.with_user(user).write({"stage_id": stage_b.id})
+
+        self.assertEqual(lead.stage_id, stage_b)
+
+    def test_stage_restriction_blocks_user_without_role(self):
+        """A user who is a team member but does NOT hold any of the
+        restriction's allowed roles must be blocked from performing the
+        restricted transition.
+        """
+        stage_a = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - No Role A", "sequence": 1}
+        )
+        stage_b = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - No Role B", "sequence": 2}
+        )
+        user = self.env["res.users"].create(
+            {
+                "name": "Stage Restriction Role Test - Unassigned User",
+                "login": "stage_restriction_role_test_norole@example.com",
+                "groups_id": [
+                    (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
+                    (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
+                ],
+            }
+        )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Role Test - No Role", "code": "SRTR-ROLE-NO"}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Role Test Team - No Role",
+                "member_ids": [(6, 0, [user.id])],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "from_stage_id": stage_a.id,
+                            "to_stage_id": stage_b.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Role Test Lead - No Role",
+                "team_id": team.id,
+                "stage_id": stage_a.id,
+            }
+        )
+
+        with self.assertRaises(UserError):
+            lead.with_user(user).write({"stage_id": stage_b.id})
+
+    def test_stage_restriction_to_any_by_role(self):
+        """A "to-only" restriction (from empty) must allow the transition
+        for a user with the allowed role regardless of origin stage, and
+        block a user without that role.
+        """
+        stage_c = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - To Any C", "sequence": 1}
+        )
+        stage_target = self.env["crm.stage"].create(
+            {"name": "Stage Restriction Role Test - To Any Target", "sequence": 2}
+        )
+        allowed_user = self.env["res.users"].create(
+            {
+                "name": "Stage Restriction Role Test - To Any Allowed",
+                "login": "stage_restriction_role_test_toany_allowed@example.com",
+                "groups_id": [
+                    (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
+                    (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
+                ],
+            }
+        )
+        other_user = self.env["res.users"].create(
+            {
+                "name": "Stage Restriction Role Test - To Any Other",
+                "login": "stage_restriction_role_test_toany_other@example.com",
+                "groups_id": [
+                    (4, self.env.ref("ssi_lead.crm_lead_user_group").id),
+                    (4, self.env.ref("ssi_lead.crm_lead_all_group").id),
+                ],
+            }
+        )
+        role = self.env["crm_team_role"].create(
+            {"name": "Stage Restriction Role Test - To Any", "code": "SRTR-TOANY"}
+        )
+        team = self.env["crm.team"].create(
+            {
+                "name": "Stage Restriction Role Test Team - To Any",
+                "member_ids": [(6, 0, [allowed_user.id, other_user.id])],
+                "member_role_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "role_id": role.id,
+                            "user_ids": [(6, 0, [allowed_user.id])],
+                        },
+                    )
+                ],
+                "stage_restriction_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "to_stage_id": stage_target.id,
+                            "role_ids": [(6, 0, [role.id])],
+                        },
+                    )
+                ],
+            }
+        )
+        lead_allowed = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Role Test Lead - To Any Allowed",
+                "team_id": team.id,
+                "stage_id": stage_c.id,
+            }
+        )
+        lead_blocked = self.env["crm.lead"].create(
+            {
+                "name": "Stage Restriction Role Test Lead - To Any Blocked",
+                "team_id": team.id,
+                "stage_id": stage_c.id,
+            }
+        )
+
+        lead_allowed.with_user(allowed_user).write({"stage_id": stage_target.id})
+        self.assertEqual(lead_allowed.stage_id, stage_target)
+
+        with self.assertRaises(UserError):
+            lead_blocked.with_user(other_user).write({"stage_id": stage_target.id})

--- a/ssi_lead/views/crm_lead_views.xml
+++ b/ssi_lead/views/crm_lead_views.xml
@@ -75,7 +75,19 @@
                         <tree>
                             <field name="stage_id" />
                             <field name="date" />
+                            <field name="user_id" />
                         </tree>
+                        <form>
+                            <group>
+                                <group>
+                                    <field name="stage_id" />
+                                    <field name="date" />
+                                </group>
+                                <group>
+                                    <field name="user_id" />
+                                </group>
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="reminders" string="Reminders">

--- a/ssi_lead/views/crm_team_views.xml
+++ b/ssi_lead/views/crm_team_views.xml
@@ -46,7 +46,21 @@
                                 name="to_stage_id"
                                 domain="[('team_id', 'in', (False, parent.id))]"
                             />
+                        <field name="role_ids" widget="many2many_tags" />
                     </tree>
+                    <form>
+                        <group>
+                            <field
+                                    name="from_stage_id"
+                                    domain="[('team_id', 'in', (False, parent.id))]"
+                                />
+                            <field
+                                    name="to_stage_id"
+                                    domain="[('team_id', 'in', (False, parent.id))]"
+                                />
+                            <field name="role_ids" widget="many2many_tags" />
+                        </group>
+                    </form>
                 </field>
             </page>
         </xpath>


### PR DESCRIPTION
## Summary

- Tambah field `user_id` ("Moved By") pada `crm.lead.stage.log`, terisi otomatis dengan user yang melakukan perpindahan/pembuatan stage. Tab "Stage History" pada form `crm.lead` menampilkan kolom ini dan membuka form inline rapi saat baris di-klik (BL-0075).
- Tambah field `role_ids` (wajib, M2M ke `crm_team_role`) pada `crm.team.stage_restriction`: sebuah aturan pembatasan kini menyatakan role apa yang BOLEH melakukan transisi. Transisi yang cocok sebuah restriction hanya diizinkan bila user pelaku memiliki salah satu role tersebut di sales team (tanpa bypass superuser) (BL-0076).
- Test BL-0065 diperbarui + skenario uji baru untuk `user_id` log dan enforcement berbasis role.

## Test plan

- [x] Unit test ditulis (YAML scenario + Python `assertRaises`) mencakup kriteria penerimaan BL-0075 & BL-0076.
- [ ] CI hijau (pre-commit, install/update `ssi_lead`, test suite).