### PR TITLE
[UPD] ssi_lead

### DIFF
--- a/ssi_lead/models/crm_team_member_role.py
+++ b/ssi_lead/models/crm_team_member_role.py
@@ -2,16 +2,13 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import fields, models
 
 
 class CrmTeamMemberRole(models.Model):
     """
     Represents the assignment of one or more users to a role within a
     sales team, e.g. Team X has 3 users playing the "Presales" role.
-    Only users who are already members of the sales team may be
-    assigned to a role in that team.
     """
 
     _name = "crm.team.member_role"
@@ -39,27 +36,5 @@ class CrmTeamMemberRole(models.Model):
         column1="member_role_id",
         column2="user_id",
         required=True,
-        help="Users filling this role. Must be members of the sales team.",
+        help="Users filling this role.",
     )
-
-    @api.constrains("user_ids", "team_id")
-    def _check_user_team_membership(self):
-        for record in self.sudo():
-            if not record._check_user_team_membership_condition():
-                error_message = _(
-                    """
-Context: Assign users to a sales team role
-Database ID: %s
-Problem: One or more users are not members of sales team "%s".
-Solution: Only assign users who are members of the team (tab Members).
-"""
-                    % (record.id, record.team_id.name)
-                )
-                raise ValidationError(error_message)
-
-    def _check_user_team_membership_condition(self):
-        self.ensure_one()
-        if not self.team_id or not self.user_ids:
-            return True
-        member_users = self.team_id.member_ids
-        return all(user in member_users for user in self.user_ids)

--- a/ssi_lead/tests/test_data_ssi_lead.yaml
+++ b/ssi_lead/tests/test_data_ssi_lead.yaml
@@ -416,3 +416,47 @@ scenarios:
           - ["id", "=", "EVAL: registry['member_role'].id"]
         save_as: "deleted_member_role"
         expect_count: 0
+
+  - name: "CRM Team Member Role - Assignment without team membership"
+    steps:
+      - step: "Create non-member user"
+        action: "create"
+        model: "res.users"
+        save_as: "non_member_user"
+        values:
+          name: "Member Role Test User Non-Member"
+          login: "member_role_test_user_non_member@example.com"
+
+      - step: "Create sales team without the non-member user"
+        action: "create"
+        model: "crm.team"
+        save_as: "non_member_team"
+        values:
+          name: "Test Sales Team Non-Member Role"
+
+      - step: "Create role for non-member assignment"
+        action: "create"
+        model: "crm_team_role"
+        save_as: "non_member_assign_role"
+        values:
+          name: "Account Manager"
+          code: "AM"
+
+      - step: "Assign non-member user to role on team"
+        action: "create"
+        model: "crm.team.member_role"
+        save_as: "non_member_role"
+        values:
+          team_id: "EVAL: registry['non_member_team'].id"
+          role_id: "EVAL: registry['non_member_assign_role'].id"
+          user_ids:
+            - "EVAL: registry['non_member_user'].id"
+
+      - step: "Assert non-member role assignment was created"
+        action: "search"
+        model: "crm.team.member_role"
+        domain:
+          - ["id", "=", "EVAL: registry['non_member_role'].id"]
+          - ["user_ids", "in", "EVAL: [registry['non_member_user'].id]"]
+        save_as: "non_member_role_created"
+        expect_count: 1

--- a/ssi_lead/tests/test_ssi_lead.py
+++ b/ssi_lead/tests/test_ssi_lead.py
@@ -13,8 +13,8 @@ class TestSsiLead(YamlTransactionCase):
     def test_ssi_lead(self):
         self.run_yaml_scenario("test_data_ssi_lead.yaml")
 
-    def test_member_role_rejects_non_team_member(self):
-        """A user who is not a member of the sales team must not be
+    def test_member_role_accepts_non_team_member(self):
+        """A user who is not a member of the sales team must still be
         assignable to a crm.team.member_role line for that team.
         """
         member_user = self.env["res.users"].create(
@@ -39,14 +39,15 @@ class TestSsiLead(YamlTransactionCase):
             {"name": "Constraint Test Role", "code": "CTR"}
         )
 
-        with self.assertRaises(ValidationError):
-            self.env["crm.team.member_role"].create(
-                {
-                    "team_id": team.id,
-                    "role_id": role.id,
-                    "user_ids": [(6, 0, [member_user.id, outsider_user.id])],
-                }
-            )
+        member_role = self.env["crm.team.member_role"].create(
+            {
+                "team_id": team.id,
+                "role_id": role.id,
+                "user_ids": [(6, 0, [member_user.id, outsider_user.id])],
+            }
+        )
+
+        self.assertIn(outsider_user, member_role.user_ids)
 
     def test_reminder_count_persists_to_db(self):
         """reminder_count must be written to DB after _send_notification so that

--- a/ssi_lead/views/crm_team_views.xml
+++ b/ssi_lead/views/crm_team_views.xml
@@ -27,11 +27,7 @@
                 <field name="member_role_ids">
                     <tree editable="bottom">
                         <field name="role_id" />
-                        <field
-                                name="user_ids"
-                                widget="many2many_tags"
-                                domain="[('sale_team_id', '=', parent.id)]"
-                            />
+                        <field name="user_ids" widget="many2many_tags" />
                     </tree>
                 </field>
             </page>


### PR DESCRIPTION
## Summary

* Menghapus constraint keanggotaan sales team pada `crm.team.member_role` (`_check_user_team_membership` dan helper-nya) beserta domain pada field `user_ids` di view Member Roles, sehingga user dapat diisi ke role tanpa harus menjadi member sales team terlebih dahulu.
* Menyesuaikan docstring dan help field yang menyebut keharusan tersebut.
* Mengganti test negatif menjadi test positif dan menambah skenario YAML untuk assignment non-member.

## Test plan

- [x] Unit test Python `test_member_role_accepts_non_team_member` (dijalankan CI)
- [x] Skenario YAML "CRM Team Member Role - Assignment without team membership" (dijalankan CI)